### PR TITLE
Add link to to gist on fallback page

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "http-proxy": "^1.12.0",
     "isparta": "^3.1.0",
     "object.assign": "^1.0.3",
+    "primer-css": "3.0.1",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",
     "vinyl-paths": "^1.0.0",
@@ -45,6 +46,7 @@
     "aurelia-pal": "^1.0.0-beta.1.2.0",
     "octicons": "github:github/octicons",
     "requirejs": "^2.2.0",
-    "requirejs-text": "^2.0.12"
+    "requirejs-text": "^2.0.12",
+    "split.js": "1.0.6"
   }
 }

--- a/src/ui/fallback.html
+++ b/src/ui/fallback.html
@@ -3,21 +3,20 @@
     <img alt="GistRun" src="img/logo.png">
     <p>
       <strong>GistRun</strong> runs and edits
-      <a href="https://gist.github.com/" target="_blank">GitHub Gists</a>. GistRun is
-      built with <a href="http://aurelia.io" target="_blank">Aurelia</a>, uses the
+      <a href="https://gist.github.com/" target="_blank">GitHub Gists</a>. GistRun is built with <a href="http://aurelia.io"
+        target="_blank">Aurelia</a>, uses the
       <a href="https://developer.github.com/v3/" target="_blank">GitHub API</a> and is hosted on
       <a href="https://pages.github.com/" target="_blank">GitHub pages</a>.
       <a href="https://www.cloudflare.com/" target="_blank">CloudFlare</a> provides DNS and
-      <a href="https://www.heroku.com/" target="_blank">Heruku</a> hosts GistRun's integration
-      with GitHub's OAuth <a href="https://developer.github.com/v3/oauth/#web-application-flow" target="_blank">
-      web application flow</a>. <em>Many thanks to the providers of these free
-      libraries and services!</em>
+      <a href="https://www.heroku.com/" target="_blank">Heruku</a> hosts GistRun's integration with GitHub's OAuth <a href="https://developer.github.com/v3/oauth/#web-application-flow"
+        target="_blank">
+        web application flow</a>. <em>Many thanks to the providers of these free
+        libraries and services!</em>
     </p>
     <div class="flash flash-error">
-      <span class="octicon octicon-alert"></span> Bummer... Your browser doesn't
-      support service workers.  Check
-      <a href="http://caniuse.com/#feat=serviceworkers" target="_blank">here</a> for a list of
-      browsers that support service workers.
+        <span class="octicon octicon-alert"></span> Bummer... Your browser doesn't support service workers. Check
+        <a href="http://caniuse.com/#feat=serviceworkers" target="_blank">here</a> for a list of browsers that support service
+        workers.<br> You can <a class="btn btn-sm btn-primary" href="${gistUrl}" role="button">access the original gist directly</a> in the meantime.
     </div>
   </section>
 </template>

--- a/src/ui/fallback.js
+++ b/src/ui/fallback.js
@@ -1,3 +1,16 @@
+import {inject} from 'aurelia-framework';
+import {QueryString} from '../editing/query-string';
+
+@inject(QueryString)
 export class UnsupportedBrowser {
-  
+  constructor(queryString) {
+    this.queryString = queryString;
+  }
+
+  activate() {
+    return this.queryString.read()
+      .then(gist => {
+        this.gistUrl = gist.html_url;
+      });
+  }
 }


### PR DESCRIPTION
Implements the fallback link suggested over at https://github.com/gist-run/gist-run/issues/31.
I also added two missing npm dependencies (`primer-css` and `split.css`), as I was not able to run the project without them.  